### PR TITLE
Fixes #3 Add the gitbook.yaml file

### DIFF
--- a/.gitbook.yaml
+++ b/.gitbook.yaml
@@ -1,0 +1,5 @@
+root: ./spec/
+
+​structure:  
+    readme: README.md  
+    summary: SUMMARY.md​


### PR DESCRIPTION
adding the .gitbook.yaml back in to the repo as it is needed to tell gitbook where to find the specifications 