### PR TITLE
TECH-173: Add mock applications to bb-information-mediator

### DIFF
--- a/examples/mock/Dockerfile
+++ b/examples/mock/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14-alpine
+
+RUN npm install -g @mockoon/cli@2.2.1
+COPY mockoon-bb-information-mediator.json ./mockoon-bb-information-mediator.json
+
+# Do not run as root.
+RUN adduser --shell /bin/sh --disabled-password --gecos "" mockoon
+RUN chown -R mockoon ./mockoon-bb-information-mediator.json
+USER mockoon
+
+EXPOSE 3003
+
+ENTRYPOINT ["mockoon-cli", "start", "--hostname", "0.0.0.0", "--daemon-off", "--data", "mockoon-bb-information-mediator.json", "--container"]
+
+# Usage: docker run -p <host_port>:<container_port> mockoon-test

--- a/examples/mock/README.md
+++ b/examples/mock/README.md
@@ -1,0 +1,21 @@
+# Mockoon API
+
+This is a mock application which performs the whole OpenAPI spec for Information
+Mediator BB.
+
+## Setup
+
+To run dockerized version of mocked API use shell script `test_entrypoint.sh`
+(requires `docker` and `docker-compose`). By default, API is available on port
+`3366`, application runs on port `3003` in Docker host. Dockerfile was created
+using mockoon-cli.
+
+## Changes in API definition
+
+To introduce changes in API definition it is necessary to change content of
+`mockoon-bb-information-mediator.json` file. It can be done using
+[mockoon application](https://mockoon.com/). After following instalation, API
+Spec can be opened from application navigation bar
+`File > Open environment > Select mockoon-bb-information-mediator.json`.
+Dockerized instance of application is not hot-reloaded, therefore it's necessary
+to restart server for changes to be applied.

--- a/examples/mock/docker-compose.yml
+++ b/examples/mock/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.3'
+
+services:
+  app:
+    image: bb-information-mediator-api-image
+    ports:
+      - 3366:3003
+    networks:
+      - web
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    volumes:
+      - ./mockoon-bb-information-mediator.json:/mockoon-bb-information-mediator.json
+
+networks:
+  web:
+    driver: bridge

--- a/examples/mock/mockoon-bb-information-mediator.json
+++ b/examples/mock/mockoon-bb-information-mediator.json
@@ -1,0 +1,151 @@
+{
+  "uuid": "a11d79ca-aee0-468b-92c0-e52293cf2b6f",
+  "lastMigration": 24,
+  "name": "Mockoon bb information mediator",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3004,
+  "hostname": "0.0.0.0",
+  "routes": [
+    {
+      "uuid": "b90a7160-a318-40b3-b216-bdebbc6f3551",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "listClients",
+      "responses": [
+        {
+          "uuid": "96813ac5-6ea1-46b4-a382-8b54eb063054",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "224e9fd8-74f8-4ece-b11f-a8ebddea756a",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/listMethods",
+      "responses": [
+        {
+          "uuid": "c5856d8f-d1ce-4b66-893a-f4607dc7e324",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "8b7983c3-cab2-4499-80f4-4b2b27461bb6",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/allowedMethods",
+      "responses": [
+        {
+          "uuid": "4af5f446-2e22-4eb3-b97d-3638fa7a1f65",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "f76233cd-2ad3-4e58-a89d-9edcf614fdd2",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI",
+      "responses": [
+        {
+          "uuid": "e297ce41-dfa2-4ca2-a951-6d6c9a43d9bf",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": []
+}

--- a/examples/mock/test_entrypoint.sh
+++ b/examples/mock/test_entrypoint.sh
@@ -1,0 +1,1 @@
+docker-compose up app


### PR DESCRIPTION
Add mock applications to bb-information-mediator.

Generic mockoon API that is being generated based on openAPI schema was created in digital-registries building block. This example application should be copied to the bb-information-mediator building blocks.

TICKET: https://govstack-global.atlassian.net/browse/TECH-173