### PR TITLE
TECH-186: Create test configuration for "/listClients" endpoint 

### DIFF
--- a/examples/mock/mockoon-bb-information-mediator.json
+++ b/examples/mock/mockoon-bb-information-mediator.json
@@ -4,21 +4,21 @@
   "name": "Mockoon bb information mediator",
   "endpointPrefix": "",
   "latency": 0,
-  "port": 3004,
+  "port": 3003,
   "hostname": "0.0.0.0",
   "routes": [
     {
       "uuid": "b90a7160-a318-40b3-b216-bdebbc6f3551",
-      "documentation": "",
+      "documentation": "List of Clients of GovStack",
       "method": "get",
       "endpoint": "listClients",
       "responses": [
         {
           "uuid": "96813ac5-6ea1-46b4-a382-8b54eb063054",
-          "body": "{}",
+          "body": "{\n  \"member\": [\n    {\n      \"objectType\": {\n        \"object_type\": \"MEMBER\"\n      },\n      \"serviceType\": \"string\",\n      \"GovStackInstance\": \"string\",\n      \"memberClass\": \"string\",\n      \"memberCode\": \"string\",\n      \"applicationCode\": \"string\",\n      \"serviceCode\": \"string\",\n      \"serviceVersion\": \"string\",\n      \"endpointList\": {\n        \"member\": [\n          {\n            \"method\": \"string\",\n            \"path\": \"string\"\n          }\n        ]\n      }\n    }\n  ]\n}",
           "latency": 0,
           "statusCode": 200,
-          "label": "",
+          "label": "Successfully retrieve the list of Clients of GovStack",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",

--- a/test/features/list_clients.feature
+++ b/test/features/list_clients.feature
@@ -1,0 +1,13 @@
+Feature: This endpoint is used to retrieve the list of clients from GovStack.
+
+  Request endpoint: GET /listClients
+
+  Scenario: Successfully retrieved the list of clients from GovStack
+    Given Wants to retrieve the the list of Clients of GovStack
+    When The request to retrieve the list of Clients of GovStack is sent
+    Then The operation returns the list of Clients of GovStack
+
+  Scenario: Successfully retrieved the list of clients from GovStack with optional parameters in the request
+    Given Wants to retrieve the list of clients from GovStack with optional parameters specified
+    When The request with optional parameters to retrieve the list of Clients of GovStack is sent
+    Then The operation returns the list of Clients of GovStack

--- a/test/features/support/helpers/helpers.js
+++ b/test/features/support/helpers/helpers.js
@@ -1,3 +1,62 @@
 module.exports = {
   localhost: 'http://localhost:3366/',
+  responseSchema: {
+    type: 'object',
+    properties: {
+      member: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            objectType: {
+              type: 'object',
+              properties: {
+                object_type: {
+                  type: 'string',
+                  enum: [
+                    'MEMBER',
+                    'SUBSYSTEM',
+                    'SERVER',
+                    'GLOBALGROUP',
+                    'SECURITYCATEGORY',
+                    'SERVICE',
+                    'CENTRALSERVICE',
+                    'LOCALGROUP',
+                  ],
+                },
+              },
+              additionalProperties: false,
+            },
+            serviceType: { type: 'string' },
+            GovStackInstance: { type: 'string' },
+            memberClass: { type: 'string' },
+            memberCode: { type: 'string' },
+            applicationCode: { type: 'string' },
+            serviceCode: { type: 'string' },
+            serviceVersion: { type: 'string' },
+            endpointList: {
+              type: 'object',
+              properties: {
+                member: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      method: { type: 'string' },
+                      path: { type: 'string' },
+                    },
+                    additionalProperties: false,
+                  },
+                },
+              },
+              additionalProperties: false,
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['member'],
+    additionalProperties: false,
+  },
 };

--- a/test/features/support/list_clients.js
+++ b/test/features/support/list_clients.js
@@ -1,0 +1,50 @@
+const { spec } = require('pactum');
+const { Given, When, Then, Before, After } = require('@cucumber/cucumber');
+const { localhost, responseSchema } = require('./helpers/helpers');
+
+let specListClients;
+
+const baseUrl = `${localhost}listClients`;
+
+Before(() => {
+  specListClients = spec().expectResponseTime(15000);
+});
+
+// Scenario: Successfully retrieved the list of Clients of GovStack
+Given(
+  'Wants to retrieve the the list of Clients of GovStack',
+  () => 'No route parameters were specified'
+);
+
+When('The request to retrieve the list of Clients of GovStack is sent', () =>
+  specListClients.get(baseUrl)
+);
+
+Then('The operation returns the list of Clients of GovStack', async () => {
+  specListClients.expectStatus(200).expectJsonSchema(responseSchema);
+  await specListClients.toss();
+});
+
+// Scenario: Successfully retrieved the list of clients from GovStack with optional parameters in the request
+Given(
+  'Wants to retrieve the list of clients from GovStack with optional parameters specified',
+  () => 'Optional parameters for the route were specified'
+);
+
+When(
+  'The request with optional parameters to retrieve the list of Clients of GovStack is sent',
+  () =>
+    specListClients
+      .get(baseUrl)
+      .withHeaders('X-GovStack-Client', 'string')
+      .withPathParams({
+        serviceId: 'string',
+        instanceId: 'string',
+      })
+);
+
+// "Then" already written in line 83-86
+
+After(() => {
+  specListClients.end();
+});


### PR DESCRIPTION
Create test configuration for /listClients endpoint from https://github.com/GovStackWorkingGroup/bb-information-mediator/blob/main/api/govstack_im_service_metadata_api-0.3-swagger.json . Write the test plan and Cucumber tests, as well as supporting code to run those Cucumber tests.

TICKET: https://govstack-global.atlassian.net/browse/TECH-186