### PR TITLE
TECH-189: Create test configuration for "/{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI" endpoint 

### DIFF
--- a/examples/mock/mockoon-bb-information-mediator.json
+++ b/examples/mock/mockoon-bb-information-mediator.json
@@ -1,6 +1,6 @@
 {
   "uuid": "a11d79ca-aee0-468b-92c0-e52293cf2b6f",
-  "lastMigration": 24,
+  "lastMigration": 25,
   "name": "Mockoon bb information mediator",
   "endpointPrefix": "",
   "latency": 0,
@@ -90,22 +90,102 @@
     },
     {
       "uuid": "f76233cd-2ad3-4e58-a89d-9edcf614fdd2",
-      "documentation": "",
+      "documentation": "OpenAPI description of the specified REST service",
       "method": "get",
-      "endpoint": "{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI",
+      "endpoint": ":GovStackInstance/:memberClass/:memberCode/:applicationCode/getOpenAPI",
       "responses": [
         {
           "uuid": "e297ce41-dfa2-4ca2-a951-6d6c9a43d9bf",
-          "body": "{}",
+          "body": "\"string\"",
           "latency": 0,
           "statusCode": 200,
-          "label": "",
+          "label": "Retrieved OpenAPI description of the specified REST service",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "params",
+              "modifier": "GovStackInstance",
+              "value": "^([a-zA-Z][a-zA-Z\\d]*)$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "params",
+              "modifier": "memberClass",
+              "value": "^([a-zA-Z][a-zA-Z\\d]*)$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "params",
+              "modifier": "memberCode",
+              "value": "^[a-zA-Z\\d]+$",
+              "invert": false,
+              "operator": "regex"
+            },
+            {
+              "target": "params",
+              "modifier": "applicationCode",
+              "value": "^[a-zA-Z\\d]+$",
+              "invert": false,
+              "operator": "regex"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false
+        },
+        {
+          "uuid": "ebcfccd5-4ace-467a-9c29-1c7d13cd9a5c",
+          "body": "",
+          "latency": 0,
+          "statusCode": 400,
+          "label": "Error in request",
           "headers": [],
           "bodyType": "INLINE",
           "filePath": "",
           "databucketID": "",
           "sendFileAsBody": false,
-          "rules": [],
+          "rules": [
+            {
+              "target": "params",
+              "modifier": "GovStackInstance",
+              "value": "^([a-zA-Z][a-zA-Z\\d]*)$",
+              "invert": true,
+              "operator": "regex"
+            },
+            {
+              "target": "params",
+              "modifier": "memberClass",
+              "value": "^([a-zA-Z][a-zA-Z\\d]*)$",
+              "invert": true,
+              "operator": "regex"
+            },
+            {
+              "target": "params",
+              "modifier": "memberCode",
+              "value": "^[a-zA-Z\\d]+$",
+              "invert": true,
+              "operator": "regex"
+            },
+            {
+              "target": "params",
+              "modifier": "applicationCode",
+              "value": "^[a-zA-Z\\d]+$",
+              "invert": true,
+              "operator": "regex"
+            }
+          ],
           "rulesOperator": "OR",
           "disableTemplating": false,
           "fallbackTo404": false,
@@ -147,5 +227,24 @@
       "value": ""
     }
   ],
-  "data": []
+  "data": [],
+  "folders": [],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "b90a7160-a318-40b3-b216-bdebbc6f3551"
+    },
+    {
+      "type": "route",
+      "uuid": "224e9fd8-74f8-4ece-b11f-a8ebddea756a"
+    },
+    {
+      "type": "route",
+      "uuid": "8b7983c3-cab2-4499-80f4-4b2b27461bb6"
+    },
+    {
+      "type": "route",
+      "uuid": "f76233cd-2ad3-4e58-a89d-9edcf614fdd2"
+    }
+  ]
 }

--- a/examples/mock/mockoon-bb-information-mediator.json
+++ b/examples/mock/mockoon-bb-information-mediator.json
@@ -114,14 +114,14 @@
             {
               "target": "params",
               "modifier": "GovStackInstance",
-              "value": "^([a-zA-Z][a-zA-Z\\d_\\-.]*)$",
+              "value": "^([a-zA-Z][a-zA-Z\\d_:\\-.]*)$",
               "invert": false,
               "operator": "regex"
             },
             {
               "target": "params",
               "modifier": "memberClass",
-              "value": "^([a-zA-Z][a-zA-Z\\d_\\-.]*)$",
+              "value": "^([a-zA-Z][a-zA-Z\\d_:\\-.]*)$",
               "invert": false,
               "operator": "regex"
             },
@@ -167,14 +167,14 @@
             {
               "target": "params",
               "modifier": "GovStackInstance",
-              "value": "^([a-zA-Z][a-zA-Z\\d_\\-.]*)$",
+              "value": "^([a-zA-Z][a-zA-Z\\d_:\\-.]*)$",
               "invert": true,
               "operator": "regex"
             },
             {
               "target": "params",
               "modifier": "memberClass",
-              "value": "^([a-zA-Z][a-zA-Z\\d_\\-.]*)$",
+              "value": "^([a-zA-Z][a-zA-Z\\d_:\\-.]*)$",
               "invert": true,
               "operator": "regex"
             },

--- a/examples/mock/mockoon-bb-information-mediator.json
+++ b/examples/mock/mockoon-bb-information-mediator.json
@@ -114,14 +114,14 @@
             {
               "target": "params",
               "modifier": "GovStackInstance",
-              "value": "^([a-zA-Z][a-zA-Z\\d]*)$",
+              "value": "^([a-zA-Z][a-zA-Z\\d_\\-.]*)$",
               "invert": false,
               "operator": "regex"
             },
             {
               "target": "params",
               "modifier": "memberClass",
-              "value": "^([a-zA-Z][a-zA-Z\\d]*)$",
+              "value": "^([a-zA-Z][a-zA-Z\\d_\\-.]*)$",
               "invert": false,
               "operator": "regex"
             },
@@ -160,14 +160,14 @@
             {
               "target": "params",
               "modifier": "GovStackInstance",
-              "value": "^([a-zA-Z][a-zA-Z\\d]*)$",
+              "value": "^([a-zA-Z][a-zA-Z\\d_\\-.]*)$",
               "invert": true,
               "operator": "regex"
             },
             {
               "target": "params",
               "modifier": "memberClass",
-              "value": "^([a-zA-Z][a-zA-Z\\d]*)$",
+              "value": "^([a-zA-Z][a-zA-Z\\d_\\-.]*)$",
               "invert": true,
               "operator": "regex"
             },

--- a/examples/mock/mockoon-bb-information-mediator.json
+++ b/examples/mock/mockoon-bb-information-mediator.json
@@ -138,6 +138,13 @@
               "value": "^[a-zA-Z\\d]+$",
               "invert": false,
               "operator": "regex"
+            },
+            {
+              "target": "query",
+              "modifier": "serviceCode",
+              "value": "^[a-zA-Z\\d]+$",
+              "invert": false,
+              "operator": "regex"
             }
           ],
           "rulesOperator": "AND",
@@ -181,6 +188,13 @@
             {
               "target": "params",
               "modifier": "applicationCode",
+              "value": "^[a-zA-Z\\d]+$",
+              "invert": true,
+              "operator": "regex"
+            },
+            {
+              "target": "query",
+              "modifier": "serviceCode",
               "value": "^[a-zA-Z\\d]+$",
               "invert": true,
               "operator": "regex"

--- a/test/features/get_open_api.feature
+++ b/test/features/get_open_api.feature
@@ -8,10 +8,10 @@ Feature: Retrieve openAPI description of the specified REST service
 
     Given User wants to retrieve the openAPI description of the specified REST service
     When User sends GET request with given "identifier" as GovStackInstance "identifier" as memberClass "alp4aNum3r1c" as memberCode "alp4aNum3r1c" as applicationCode
-    Then User receives a resonse
-    And The response should match json schema
-    And The response should have status 200
+    Then User receives a response
     And The response should be returned in a timely manner
+    And The response should have status 200
+    And The response should match json schema
 
 
   @unit @happyregression
@@ -19,12 +19,11 @@ Feature: Retrieve openAPI description of the specified REST service
 
     Given User wants to retrieve the openAPI description of the specified REST service
     When User sends GET request with given "<GovStackInstance>" as GovStackInstance "<memberClass>" as memberClass "<memberCode>" as memberCode "<applicationCode>" as applicationCode
-    Then User receives a resonse
-    And The response should match json schema
-    And The response should have status 200
+    Then User receives a response
     And The response should be returned in a timely manner
+    And The response should have status 200
     And The response header content-type should be "application/json; charset=utf-8"
-    
+    And The response should match json schema
     
     Examples: Valid data
     | GovStackInstance | memberClass | memberCode   | applicationCode |
@@ -39,10 +38,10 @@ Feature: Retrieve openAPI description of the specified REST service
 
     Given User wants to retrieve the openAPI description of the specified REST service
     When User sends GET request with given "<GovStackInstance>" as GovStackInstance "<memberClass>" as memberClass "<memberCode>" as memberCode "<applicationCode>" as applicationCode
-    Then User receives a resonse
-    And The response should match json schema
-    And The response should have status 400
+    Then User receives a response
     And The response should be returned in a timely manner
+    And The response should have status 400
+    And The response should match json schema
     
     Examples: Invalid data
     | GovStackInstance | memberClass | memberCode   | applicationCode |

--- a/test/features/get_open_api.feature
+++ b/test/features/get_open_api.feature
@@ -1,4 +1,4 @@
-# @method=GET @endpoint=/{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI
+@method=GET @endpoint=/{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI
 Feature: Retrieve openAPI description of the specified REST service
 
   Retrieve openAPI description of the specified REST service
@@ -8,17 +8,19 @@ Feature: Retrieve openAPI description of the specified REST service
 
     Given User wants to retrieve the openAPI description of the specified REST service
     When User sends GET request with given "identifier" as GovStackInstance "identifier" as memberClass "alp4aNum3r1c" as memberCode "alp4aNum3r1c" as applicationCode
+    And User provides query parameter "alp4aNum3r1c" as serviceCode
     Then User receives a response
     And The response should be returned in a timely manner
     And The response should have status 200
     And The response should match json schema
 
 
-  @unit @happyregression
+  @unit @positive
   Scenario Outline: Retrieve the openAPI description of the specified REST service
 
     Given User wants to retrieve the openAPI description of the specified REST service
     When User sends GET request with given "<GovStackInstance>" as GovStackInstance "<memberClass>" as memberClass "<memberCode>" as memberCode "<applicationCode>" as applicationCode
+    And User provides query parameter "alp4aNum3r1c" as serviceCode
     Then User receives a response
     And The response should be returned in a timely manner
     And The response should have status 200
@@ -33,11 +35,12 @@ Feature: Retrieve openAPI description of the specified REST service
     | valid1dentifi3r  | rand0mid3nt | str1ng       | azxcv55         |
 
 
-  @unit @negativeregression
-  Scenario Outline: Unable to retrieve the openAPI description of the specified REST service
+  @unit @negative
+  Scenario Outline: Unable to retrieve the openAPI description of the specified REST service because of an invalid path parameter
 
     Given User wants to retrieve the openAPI description of the specified REST service
     When User sends GET request with given "<GovStackInstance>" as GovStackInstance "<memberClass>" as memberClass "<memberCode>" as memberCode "<applicationCode>" as applicationCode
+    And User provides query parameter "alp4aNum3r1c" as serviceCode
     Then User receives a response
     And The response should be returned in a timely manner
     And The response should have status 400
@@ -50,3 +53,31 @@ Feature: Retrieve openAPI description of the specified REST service
     | identifier       | identifier  | _invalid     | alp4aNum3r1c    |
     | identifier       | identifier  | str1ng       | _invalid        |
     | 1nval1d          | 1nval1d     | _invalid     | _invalid        |
+
+
+  @unit @negative
+  Scenario Outline: Unable to retrieve the openAPI description of the specified REST service because of an invalid serviceCode parameter
+
+    Given User wants to retrieve the openAPI description of the specified REST service
+    When User sends GET request with given "identifier" as GovStackInstance "identifier" as memberClass "alp4aNum3r1c" as memberCode "alp4aNum3r1c" as applicationCode
+    And User provides query parameter "<serviceCode>" as serviceCode
+    Then User receives a response
+    And The response should be returned in a timely manner
+    And The response should have status 400
+    And The response should match json schema
+    
+    Examples: Invalid data
+    | serviceCode   |
+    | _invalid      |
+    |               |
+
+
+  @unit @negative
+  Scenario: Unable to retrieve the openAPI description of the specified REST service because of missing serviceCode parameter
+
+    Given User wants to retrieve the openAPI description of the specified REST service
+    When User sends GET request with given "identifier" as GovStackInstance "identifier" as memberClass "alp4aNum3r1c" as memberCode "alp4aNum3r1c" as applicationCode
+    Then User receives a response
+    And The response should be returned in a timely manner
+    And The response should have status 400
+    And The response should match json schema

--- a/test/features/get_open_api.feature
+++ b/test/features/get_open_api.feature
@@ -1,0 +1,53 @@
+# @method=GET @endpoint=/{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI
+Feature: Retrieve openAPI description of the specified REST service
+
+  Retrieve openAPI description of the specified REST service
+
+  @smoke
+  Scenario: Retrieve the openAPI description of the specified REST service smoke type test
+
+    Given User wants to retrieve the openAPI description of the specified REST service
+    When User sends GET request with given "identifier" as GovStackInstance "identifier" as memberClass "alp4aNum3r1c" as memberCode "alp4aNum3r1c" as applicationCode
+    Then User receives a resonse
+    And The response should match json schema
+    And The response should have status 200
+    And The response should be returned in a timely manner
+
+
+  @unit @happyregression
+  Scenario Outline: Retrieve the openAPI description of the specified REST service
+
+    Given User wants to retrieve the openAPI description of the specified REST service
+    When User sends GET request with given "<GovStackInstance>" as GovStackInstance "<memberClass>" as memberClass "<memberCode>" as memberCode "<applicationCode>" as applicationCode
+    Then User receives a resonse
+    And The response should match json schema
+    And The response should have status 200
+    And The response should be returned in a timely manner
+    And The response header content-type should be "application/json; charset=utf-8"
+    
+    
+    Examples: Valid data
+    | GovStackInstance | memberClass | memberCode   | applicationCode |
+    | identifier       | identifier  | alp4aNum3r1c | alp4aNum3r1c    |
+    | a11a11a11a       | asd2211a    | 12as12       | m3mb3rc0d3      |
+    | a552example      | zzz321a     | m3mb3rc0d3   | aa15            |
+    | valid1dentifi3r  | rand0mid3nt | str1ng       | azxcv55         |
+
+
+  @unit @negativeregression
+  Scenario Outline: Unable to retrieve the openAPI description of the specified REST service
+
+    Given User wants to retrieve the openAPI description of the specified REST service
+    When User sends GET request with given "<GovStackInstance>" as GovStackInstance "<memberClass>" as memberClass "<memberCode>" as memberCode "<applicationCode>" as applicationCode
+    Then User receives a resonse
+    And The response should match json schema
+    And The response should have status 400
+    And The response should be returned in a timely manner
+    
+    Examples: Invalid data
+    | GovStackInstance | memberClass | memberCode   | applicationCode |
+    | 1nval1d          | identifier  | alp4aNum3r1c | alp4aNum3r1c    |
+    | identifier       | 1nval1d     | alp4aNum3r1c | alp4aNum3r1c    |
+    | identifier       | identifier  | _invalid     | alp4aNum3r1c    |
+    | identifier       | identifier  | str1ng       | _invalid        |
+    | 1nval1d          | 1nval1d     | _invalid     | _invalid        |

--- a/test/features/support/get_open_api.js
+++ b/test/features/support/get_open_api.js
@@ -20,7 +20,8 @@ Before(() => {
 // Scenario: Retrieve the openAPI description of the specified REST service smoke type test
 Given(
   'User wants to retrieve the openAPI description of the specified REST service',
-  () => ''
+  () =>
+    'User wants to retrieve the openAPI description of the specified REST service'
 );
 
 When(
@@ -34,22 +35,22 @@ When(
     })
 );
 
-Then('User receives a resonse', async () => await specGetOpenAPI.toss());
+Then('User receives a response', async () => await specGetOpenAPI.toss());
 
-Then('The response should match json schema', () =>
-  chai
-    .expect(specGetOpenAPI._response.json)
-    .to.be.jsonSchema(getOpenApiExpectedSchema)
+Then('The response should be returned in a timely manner', () =>
+  specGetOpenAPI
+    .response()
+    .to.have.responseTimeLessThan(defaultExpectedResponseTime)
 );
 
 Then('The response should have status 200', () =>
   specGetOpenAPI.response().to.have.status(200)
 );
 
-Then('The response should be returned in a timely manner', () =>
-  specGetOpenAPI
-    .response()
-    .to.have.responseTimeLessThan(defaultExpectedResponseTime)
+Then('The response should match json schema', () =>
+  chai
+    .expect(specGetOpenAPI._response.json)
+    .to.be.jsonSchema(getOpenApiExpectedSchema)
 );
 
 // Scenario: Retrieve the openAPI description of the specified REST service

--- a/test/features/support/get_open_api.js
+++ b/test/features/support/get_open_api.js
@@ -36,23 +36,23 @@ When(
 
 Then('User receives a resonse', async () => await specGetOpenAPI.toss());
 
-Then('The response should have status 200', () =>
-  specGetOpenAPI.response().to.have.status(200)
-);
-
-// Scenario: Retrieve the openAPI description of the specified REST service
-Then('The response should be returned in a timely manner', () =>
-  specGetOpenAPI
-    .response()
-    .to.have.responseTimeLessThan(defaultExpectedResponseTime)
-);
-
 Then('The response should match json schema', () =>
   chai
     .expect(specGetOpenAPI._response.json)
     .to.be.jsonSchema(getOpenApiExpectedSchema)
 );
 
+Then('The response should have status 200', () =>
+  specGetOpenAPI.response().to.have.status(200)
+);
+
+Then('The response should be returned in a timely manner', () =>
+  specGetOpenAPI
+    .response()
+    .to.have.responseTimeLessThan(defaultExpectedResponseTime)
+);
+
+// Scenario: Retrieve the openAPI description of the specified REST service
 Then('The response header content-type should be {string}', expected =>
   specGetOpenAPI.response().to.have.header('content-type', expected)
 );

--- a/test/features/support/get_open_api.js
+++ b/test/features/support/get_open_api.js
@@ -1,0 +1,67 @@
+const chai = require('chai');
+const { spec } = require('pactum');
+const { Before, Given, When, Then, After } = require('@cucumber/cucumber');
+const {
+  localhost,
+  getOpenApiUrl,
+  defaultExpectedResponseTime,
+  getOpenApiExpectedSchema,
+} = require('./helpers/helpers');
+
+chai.use(require('chai-json-schema'));
+
+let specGetOpenAPI;
+const baseUrl = localhost + getOpenApiUrl;
+
+Before(() => {
+  specGetOpenAPI = spec();
+});
+
+// Scenario: Retrieve the openAPI description of the specified REST service smoke type test
+Given(
+  'User wants to retrieve the openAPI description of the specified REST service',
+  () => ''
+);
+
+When(
+  'User sends GET request with given {string} as GovStackInstance {string} as memberClass {string} as memberCode {string} as applicationCode',
+  (GovStackInstance, memberClass, memberCode, applicationCode) =>
+    specGetOpenAPI.get(baseUrl).withPathParams({
+      GovStackInstance: GovStackInstance,
+      memberClass: memberClass,
+      memberCode: memberCode,
+      applicationCode: applicationCode,
+    })
+);
+
+Then('User receives a resonse', async () => await specGetOpenAPI.toss());
+
+Then('The response should have status 200', () =>
+  specGetOpenAPI.response().to.have.status(200)
+);
+
+// Scenario: Retrieve the openAPI description of the specified REST service
+Then('The response should be returned in a timely manner', () =>
+  specGetOpenAPI
+    .response()
+    .to.have.responseTimeLessThan(defaultExpectedResponseTime)
+);
+
+Then('The response should match json schema', () =>
+  chai
+    .expect(specGetOpenAPI._response.json)
+    .to.be.jsonSchema(getOpenApiExpectedSchema)
+);
+
+Then('The response header content-type should be {string}', expected =>
+  specGetOpenAPI.response().to.have.header('content-type', expected)
+);
+
+// Scenario: Unable to retrieve the openAPI description of the specified REST service
+Then('The response should have status 400', () =>
+  specGetOpenAPI.response().to.have.status(400)
+);
+
+After(() => {
+  specGetOpenAPI.end();
+});

--- a/test/features/support/get_open_api.js
+++ b/test/features/support/get_open_api.js
@@ -3,7 +3,7 @@ const { spec } = require('pactum');
 const { Before, Given, When, Then, After } = require('@cucumber/cucumber');
 const {
   localhost,
-  getOpenApiUrl,
+  getOpenApiEndpoint,
   defaultExpectedResponseTime,
   getOpenApiExpectedSchema,
 } = require('./helpers/helpers');
@@ -11,9 +11,10 @@ const {
 chai.use(require('chai-json-schema'));
 
 let specGetOpenAPI;
-const baseUrl = localhost + getOpenApiUrl;
+const baseUrl = localhost + getOpenApiEndpoint;
+const tag = { tags: `@endpoint=/${getOpenApiEndpoint}` };
 
-Before(() => {
+Before(tag, () => {
   specGetOpenAPI = spec();
 });
 
@@ -35,6 +36,10 @@ When(
     })
 );
 
+When('User provides query parameter {string} as serviceCode', serviceCode => {
+  specGetOpenAPI.withQueryParams('serviceCode', serviceCode);
+});
+
 Then('User receives a response', async () => await specGetOpenAPI.toss());
 
 Then('The response should be returned in a timely manner', () =>
@@ -53,16 +58,20 @@ Then('The response should match json schema', () =>
     .to.be.jsonSchema(getOpenApiExpectedSchema)
 );
 
-// Scenario: Retrieve the openAPI description of the specified REST service
+// Scenario Outline: Retrieve the openAPI description of the specified REST service
 Then('The response header content-type should be {string}', expected =>
   specGetOpenAPI.response().to.have.header('content-type', expected)
 );
 
-// Scenario: Unable to retrieve the openAPI description of the specified REST service
+// Scenario Outline: Unable to retrieve the openAPI description of the specified REST service of an invalid path parameter
 Then('The response should have status 400', () =>
   specGetOpenAPI.response().to.have.status(400)
 );
 
-After(() => {
+// Scenario Outline: Unable to retrieve the openAPI description of the specified REST service of an invalid serviceCode parameter
+
+// Scenario: Unable to retrieve the openAPI description of the specified REST service because of missing serviceCode parameter
+
+After(tag, () => {
   specGetOpenAPI.end();
 });

--- a/test/features/support/get_open_api.js
+++ b/test/features/support/get_open_api.js
@@ -69,8 +69,10 @@ Then('The response should have status 400', () =>
 );
 
 // Scenario Outline: Unable to retrieve the openAPI description of the specified REST service of an invalid serviceCode parameter
+// Code for this scenario is taken from the aforementioned steps, based on .feature file
 
 // Scenario: Unable to retrieve the openAPI description of the specified REST service because of missing serviceCode parameter
+// Code for this scenario is taken from the aforementioned steps, based on .feature file
 
 After(tag, () => {
   specGetOpenAPI.end();

--- a/test/features/support/helpers/helpers.js
+++ b/test/features/support/helpers/helpers.js
@@ -1,6 +1,6 @@
 module.exports = {
   localhost: 'http://localhost:3366/',
-  getOpenApiUrl:
+  getOpenApiEndpoint:
     '{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI',
   defaultExpectedResponseTime: 15000,
   getOpenApiExpectedSchema: {

--- a/test/features/support/helpers/helpers.js
+++ b/test/features/support/helpers/helpers.js
@@ -1,5 +1,11 @@
 module.exports = {
   localhost: 'http://localhost:3366/',
+  getOpenApiUrl:
+    '{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI',
+  defaultExpectedResponseTime: 15000,
+  getOpenApiExpectedSchema: {
+    type: 'string',
+  },
   responseSchema: {
     type: 'object',
     properties: {

--- a/test/package.json
+++ b/test/package.json
@@ -7,5 +7,9 @@
   "devDependencies": {
     "@cucumber/cucumber": "8.10.0",
     "pactum": "3.3.2"
+  },
+  "dependencies": {
+    "chai": "4.3.7",
+    "chai-json-schema": "1.5.1"
   }
 }

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -199,6 +199,11 @@ assertion-error-formatter@^3.0.0:
     pad-right "^0.2.2"
     repeat-string "^1.6.1"
 
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -236,6 +241,27 @@ centra@^2.6.0:
   resolved "https://registry.yarnpkg.com/centra/-/centra-2.6.0.tgz#79117998ee6908642258db263871381aa5d1204a"
   integrity sha512-dgh+YleemrT8u85QL11Z6tYhegAs3MMxsaWAq/oXeAmYJ7VxL3SI9TZtnfaEvNDMAPolj25FXIb3S+HCI4wQaQ==
 
+chai-json-schema@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/chai-json-schema/-/chai-json-schema-1.5.1.tgz#d9ae4c8f8c6e24ff4d402ceddfaa865d1ca107f4"
+  integrity sha512-TR/xPDxRhqwFFCWg1HgL8nNWbpNfUwaib6pBN++QKpnd0t+o3+MBvAn5CM1mpdUMaM76oJAtUjGKdjGad01lIA==
+  dependencies:
+    jsonpointer.js "0.4.0"
+    tv4 "^1.3.0"
+
+chai@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
+  integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^4.1.2"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -243,6 +269,11 @@ chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 class-transformer@0.5.1:
   version "0.5.1"
@@ -309,6 +340,13 @@ debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+deep-eql@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
+  dependencies:
+    type-detect "^4.0.0"
+
 deep-override@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/deep-override/-/deep-override-1.0.2.tgz#82a98ff187a33d2e146a927450773a8aaac2c716"
@@ -371,6 +409,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
 
 glob@^7.1.3, glob@^7.1.6:
   version "7.2.3"
@@ -454,6 +497,11 @@ json-query@^2.2.2:
   resolved "https://registry.yarnpkg.com/json-query/-/json-query-2.2.2.tgz#b6558b8a3794ccd217926aa38024324b77b48ab1"
   integrity sha512-y+IcVZSdqNmS4fO8t1uZF6RMMs0xh3SrTjJr9bp1X3+v0Q13+7Cyv12dSmKwDswp/H427BVtpkLWhGxYu3ZWRA==
 
+jsonpointer.js@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer.js/-/jsonpointer.js-0.4.0.tgz#002cb123f767aafdeb0196132ce5c4f9941ccaba"
+  integrity sha512-2bf/1crAmPpsmj1I6rDT6W0SOErkrNBpb555xNWcMVWYrX6VnXpG0GRMQ2shvOHwafpfse8q0gnzPFYVH6Tqdg==
+
 klona@^2.0.4, klona@^2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.6.tgz#85bffbf819c03b2f53270412420a4555ef882e22"
@@ -490,6 +538,13 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+loupe@^2.3.1:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
+  integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
+  dependencies:
+    get-func-name "^2.0.0"
 
 lower-case@^2.0.2:
   version "2.0.2"
@@ -613,6 +668,11 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 phin@^3.7.0:
   version "3.7.0"
@@ -787,6 +847,16 @@ tslib@^2.0.3:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tv4@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.3.0.tgz#d020c846fadd50c855abb25ebaecc68fc10f7963"
+  integrity sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 upper-case-first@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Created mocks and Cucumber tests for getOpenAPI endpoint.

**Description**
Create test configuration for /{GovStackInstance}/{memberClass}/{memberCode}/{applicationCode}/getOpenAPI endpoint from https://github.com/GovStackWorkingGroup/bb-information-mediator/blob/main/api/govstack_im_service_metadata_api-0.3-swagger.json .This should include all the steps that are pointed out in the parent ticket.

TICKET: https://govstack-global.atlassian.net/browse/TECH-189