### PR TITLE
TECH-459: Fix wait in tests

### DIFF
--- a/test/openAPI/docker/entrypoint.sh
+++ b/test/openAPI/docker/entrypoint.sh
@@ -20,9 +20,9 @@ healthcheckApiCall() {
     echo "-----"
     curl ${API_URL}
     RETURN=$?
-    if [ $RETURN -eq 7 ];
+    if [ $RETURN -ne 0 ];
     then
-      echo "Api healthcheck call failed, curl returned status code 7"
+      echo "Api healthcheck call failed"
       return 1
     fi
     echo "-----"


### PR DESCRIPTION
We shouldn't just check for a specific error code returned from curl, any error code indicates we should wait.

This should fix random failures on CI.
